### PR TITLE
Relative errors for sw targets

### DIFF
--- a/src/SingleChain.py
+++ b/src/SingleChain.py
@@ -162,6 +162,10 @@ class SingleChain(object):
                 continue
 
             if target_noise_corr == 0:
+                if target.obsdata.y_err is not None:
+                    # diagonals of covariance matrix scaled by relative error
+                    target.get_covariance = target.valuation.get_covariance_nocorr_relative_error
+                    continue
                 # diagonal for each target, corr inrelevant for likelihood
                 target.get_covariance = target.valuation.get_covariance_nocorr
                 continue


### PR DESCRIPTION
These are the changes for relative errors for sw targets.
I had to pass obs rather than size to target.get_covariance(), so there are a number of changes as a result of that.